### PR TITLE
Caddy `v2.10.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG LITESTREAM_SHA256="eb75a3de5cab03875cdae9f5f539e6aedadd66607003d9b1e7a907794
 # ---
 # Container version args
 # Bump these every time there is a new release. No checksum needed.
-ARG CADDY_VERSION="2.9.1"
+ARG CADDY_VERSION="2.10.0"
 ARG MAIN_IMAGE_ALPINE_VERSION="3.21.3"
 ARG HEADSCALE_ADMIN_VERSION="0.25.6"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.25.1`](https://github.com/juanfont/headscale/releases/tag/v0.25.1) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`v0.25.6`](https://github.com/GoodiesHQ/headscale-admin/releases/tag/v0.25.6) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`v0.3.13`](https://github.com/benbjohnson/litestream/releases/tag/v0.3.13) |
-| [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.9.1`](https://github.com/caddyserver/caddy/releases/tag/v2.9.1) |
+| [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.10.0`](https://github.com/caddyserver/caddy/releases/tag/v2.10.0) |
 
 ## Versioning
 


### PR DESCRIPTION
Brings along [`Encrypted Client Hello` capability](https://caddyserver.com/docs/automatic-https#encrypted-clienthello-ech) amongst other goodies