### PR TITLE
Move to headscale-admin `dev` branch to handle headscale's version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG LITESTREAM_SHA256="eb75a3de5cab03875cdae9f5f539e6aedadd66607003d9b1e7a907794
 # Bump these every time there is a new release. No checksum needed.
 ARG CADDY_VERSION="2.10.0"
 ARG MAIN_IMAGE_ALPINE_VERSION="3.22.0"
-ARG HEADSCALE_ADMIN_VERSION="0.25.6"
+ARG HEADSCALE_ADMIN_VERSION="dev"
 
 # ---
 # Tool download links

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 |---|---|---|
 | [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.22.0`](https://git.alpinelinux.org/aports/log/?h=v3.22.0) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.26.0`](https://github.com/juanfont/headscale/releases/tag/v0.26.0) |
-| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`v0.25.6`](https://github.com/GoodiesHQ/headscale-admin/releases/tag/v0.25.6) |
+| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`dev`](https://github.com/GoodiesHQ/headscale-admin/commit/6cf2bc7d59165757a70f4c918a032225eb5e6e7d) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`v0.3.13`](https://github.com/benbjohnson/litestream/releases/tag/v0.3.13) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.10.0`](https://github.com/caddyserver/caddy/releases/tag/v2.10.0) |
 


### PR DESCRIPTION
We'll switch back to a version when it's released
