### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-with-smoke-tests.yml
+++ b/.github/workflows/build-with-smoke-tests.yml
@@ -1,5 +1,8 @@
 name: Deployment Checker with Smoke Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "develop" ]


### PR DESCRIPTION
Potential fix for [https://github.com/privacyint/docker-headscale/security/code-scanning/10](https://github.com/privacyint/docker-headscale/security/code-scanning/10)

To fix the problem, you should add a `permissions:` key to restrict the GITHUB_TOKEN permissions for this workflow. The least privilege required for the workflow should be specified. Given the current usage (checking out code, running tests, caching), the only necessary permission is typically read access to repository contents. You should add `permissions:` at the root level (before `jobs:`), setting `contents: read`. This ensures that any job not needing additional permissions is restricted to read-only access. No additional imports, definitions, or other changes are required—just the addition of the permissions YAML block. The edit should be made near the start of the file, after the `name:` and before `on:` or directly before `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
