### PR TITLE
Bump `headscale` to `v0.27.1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 # Tool version arguments
 # Bump these every time there is a new release.
 # We're pulling these from github source, don't forget to bump the checksum!
-ARG HEADSCALE_VERSION="0.27.0"
-ARG HEADSCALE_SHA256="d7f61f8078c6c1767b30bf8166b714fe15f4bf72162d4c2619b2f69280a597a5"
+ARG HEADSCALE_VERSION="0.27.1"
+ARG HEADSCALE_SHA256="af2a232ff407c100f05980b4d8fceaafc7fdb2e8de5eba8e184a8bb029cb6c00"
 
 ARG LITESTREAM_VERSION="0.5.2"
 ARG LITESTREAM_SHA256="235da234edd2c7140b702f1a53ecdad996040b7afaf03b4dcf9620d7998cd830"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | Tool | Upstream Repository | Version |
 |---|---|---|
 | [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.22.1`](https://git.alpinelinux.org/aports/log/?h=v3.22.1) |
-| [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.27.0`](https://github.com/juanfont/headscale/releases/tag/v0.27.0) |
+| [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.27.1`](https://github.com/juanfont/headscale/releases/tag/v0.27.1) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`0.26.0`](https://github.com/GoodiesHQ/headscale-admin/commit/6cf2bc7d59165757a70f4c918a032225eb5e6e7d) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`v0.5.2`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.2) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.10.2`](https://github.com/caddyserver/caddy/releases/tag/v2.10.2) |


### PR DESCRIPTION
https://github.com/juanfont/headscale/releases/tag/v0.27.1