### PR TITLE
Make `ephemeral_node_inactivity_timeout` a var

### DIFF
--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -445,7 +445,7 @@ display_configuration_summary() {
 	log_info "Tailnet Base Domain: ${HEADSCALE_DNS_BASE_DOMAIN}"
 	log_info "Public Listening Port: ${PUBLIC_LISTEN_PORT}"
 	log_info "GOMAXPROCS: ${GOMAXPROCS}"
-	log_info "Ephemeral Node Inactivity Timeout: " "${EPHEMERAL_NODE_INACTIVITY_TIMEOUT}"
+	log_info "Ephemeral Node Inactivity Timeout: ${EPHEMERAL_NODE_INACTIVITY_TIMEOUT}"
 
 	log_feature_status "HTTPS Mode" "${https_enabled}" "" "warn"
 	log_feature_status "Litestream" "${litestream_enabled}" "${LITESTREAM_REPLICA_URL}" "warn"

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -192,7 +192,7 @@ check_headscale_environment_vars() {
 	check_env_var_or_set_default "MAGIC_DNS" "${headscale_magic_dns_default}" "^(true|false)$" "Invalid 'MAGIC_DNS'. Must be 'true' or 'false'."
 	require_env_var "PUBLIC_SERVER_URL"
 	require_env_var "HEADSCALE_DNS_BASE_DOMAIN"
-	check_env_var_or_set_default "EPHEMERAL_NODE_INACTIVITY_TIMEOUT" "${headscale_ephemeral_node_inactivity_timeout_default}"
+	check_env_var_or_set_default "EPHEMERAL_NODE_INACTIVITY_TIMEOUT" "${headscale_ephemeral_node_inactivity_timeout_default}" "^[0-9]+[smhd]([0-9]+[smhd])*$" "Invalid 'EPHEMERAL_NODE_INACTIVITY_TIMEOUT'. Must be a valid duration (e.g., '30m', '1h', '90s')."
 }
 
 #######################################

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -192,6 +192,7 @@ check_headscale_environment_vars() {
 	check_env_var_or_set_default "MAGIC_DNS" "${headscale_magic_dns_default}" "^(true|false)$" "Invalid 'MAGIC_DNS'. Must be 'true' or 'false'."
 	require_env_var "PUBLIC_SERVER_URL"
 	require_env_var "HEADSCALE_DNS_BASE_DOMAIN"
+	check_env_var_or_set_default "EPHEMERAL_NODE_INACTIVITY_TIMEOUT" "${headscale_ephemeral_node_inactivity_timeout_default}"
 }
 
 #######################################
@@ -418,6 +419,7 @@ check_config_files() {
 		"MAGIC_DNS"
 		"IP_ALLOCATION"
 		"HEADSCALE_EXTRA_RECORDS_PATH"
+		"EPHEMERAL_NODE_INACTIVITY_TIMEOUT"
 	)
 	for var in "${template_vars[@]}"; do
 		export "${var}=${!var}"
@@ -443,6 +445,7 @@ display_configuration_summary() {
 	log_info "Tailnet Base Domain: ${HEADSCALE_DNS_BASE_DOMAIN}"
 	log_info "Public Listening Port: ${PUBLIC_LISTEN_PORT}"
 	log_info "GOMAXPROCS: ${GOMAXPROCS}"
+	log_info "Ephemeral Node Inactivity Timeout: " "${EPHEMERAL_NODE_INACTIVITY_TIMEOUT}"
 
 	log_feature_status "HTTPS Mode" "${https_enabled}" "" "warn"
 	log_feature_status "Litestream" "${litestream_enabled}" "${LITESTREAM_REPLICA_URL}" "warn"

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -2,6 +2,7 @@
 # shellcheck disable=SC2034 # This is a defaults file
 public_listen_port_default=443
 
+headscale_ephemeral_node_inactivity_timeout_default="30m"
 headscale_extra_records_path_default="/data/headscale/extra-records.json"
 headscale_magic_dns_default="true"
 headscale_ipv6_only_default="false"

--- a/templates/headscale.template.yaml
+++ b/templates/headscale.template.yaml
@@ -135,7 +135,7 @@ derp:
 disable_check_updates: true
 
 # Time before an inactive ephemeral node is deleted?
-ephemeral_node_inactivity_timeout: 30m
+ephemeral_node_inactivity_timeout: $EPHEMERAL_NODE_INACTIVITY_TIMEOUT
 
 database:
   # Database type. Available options: sqlite, postgres


### PR DESCRIPTION
Keep a default of 30m, allow changes through an environment var
This pull request introduces support for configuring the ephemeral node inactivity timeout via an environment variable, improving flexibility and consistency in the container setup. The changes ensure that the timeout value can be set using `EPHEMERAL_NODE_INACTIVITY_TIMEOUT`, with a sensible default and visibility in configuration summaries.

**Ephemeral Node Inactivity Timeout Configuration:**

* Added a default value for `headscale_ephemeral_node_inactivity_timeout_default` ("30m") in `scripts/defaults.sh` to ensure a baseline timeout is set if not provided.
* Updated the `check_headscale_environment_vars` function in `scripts/container-entrypoint.sh` to check or set the `EPHEMERAL_NODE_INACTIVITY_TIMEOUT` environment variable.
* Included `EPHEMERAL_NODE_INACTIVITY_TIMEOUT` in the list of template variables exported for configuration generation in `scripts/container-entrypoint.sh`.
* Modified the configuration template (`templates/headscale.template.yaml`) to use the `EPHEMERAL_NODE_INACTIVITY_TIMEOUT` environment variable for the `ephemeral_node_inactivity_timeout` setting.

**Configuration Visibility:**

* Enhanced the configuration summary output to display the value of `EPHEMERAL_NODE_INACTIVITY_TIMEOUT` for easier verification and debugging.