### PR TITLE
Bump base Alpine Linux version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG LITESTREAM_SHA256="47ff03852c56d0af896eb890ed3ab006fd9916d80698186a494cfd6b4
 
 # No checksum needed for these tools, we pull from official images
 ARG CADDY_VERSION="2.10.2"
-ARG MAIN_IMAGE_ALPINE_VERSION="3.22.1"
+ARG MAIN_IMAGE_ALPINE_VERSION="3.23.2"
 ARG HEADSCALE_ADMIN_VERSION="0.26.0"
 
 # github download links

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 
 | Tool | Upstream Repository | Version |
 |---|---|---|
-| [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.22.1`](https://git.alpinelinux.org/aports/log/?h=v3.22.1) |
+| [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.2`](https://git.alpinelinux.org/aports/log/?h=v3.23.2) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.27.1`](https://github.com/juanfont/headscale/releases/tag/v0.27.1) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`0.26.0`](https://github.com/GoodiesHQ/headscale-admin/commit/6cf2bc7d59165757a70f4c918a032225eb5e6e7d) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`v0.5.5`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.5) |


### PR DESCRIPTION
This pull request updates the Alpine Linux base image version used in the project from 3.22.1 to 3.23.2. The most important changes are:

Dependency updates:

* Updated the `MAIN_IMAGE_ALPINE_VERSION` argument in the `Dockerfile` to use Alpine Linux version 3.23.2 instead of 3.22.1.
* Updated the version reference for Alpine Linux in the `README.md` to reflect the new version 3.23.2.