### PR TITLE
Refactor out redundant logic

### DIFF
--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -465,7 +465,7 @@ start_caddy_service() {
 	log_info "Starting Caddy using our environment variables."
 
 	caddy start --config "${caddy_config_file}" || {
-		log_error "Failed to start Caddy"
+		log_error "Failed to start Caddy (config: ${caddy_config_file}, HTTPS: ${https_enabled})"
 		return
 	}
 

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -360,8 +360,8 @@ reuse_or_create_noise_private_key() {
 	fi
 
 	if env_var_is_defined "HEADSCALE_NOISE_PRIVATE_KEY"; then
-	    printf '%s' "${HEADSCALE_NOISE_PRIVATE_KEY}" > "${key_path}"
-        chmod 600 "${key_path}"
+		printf '%s' "${HEADSCALE_NOISE_PRIVATE_KEY}" > "${key_path}"
+		chmod 600 "${key_path}"
 	else
 		log_info "Generating new Noise private key - existing clients will need to re-authenticate"
 	fi

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -17,6 +17,7 @@ declare helper_scripts=(
 abort_config=false
 litestream_enabled=true
 https_enabled=true
+caddy_config_file=""
 
 # Caddyfile block placeholders 
 ACME_EAB_BLOCK=""
@@ -221,17 +222,6 @@ create_headscale_config() {
 }
 
 #######################################
-# Create our Caddyfile
-#######################################
-create_caddyfile() {
-	if ${https_enabled}; then
-		create_config_from_template "${caddyfile_https}" "Caddy HTTPS configuration file"
-	else
-		create_config_from_template "${caddyfile_cleartext}" "Caddy HTTP configuration file"
-	fi
-}
-
-#######################################
 # Validate ZeroSSL EAB credentials if provided and modify Caddyfile as needed
 #######################################
 check_zerossl_eab() {
@@ -353,6 +343,9 @@ check_caddy_environment_variables() {
 
 	if env_var_is_defined "CADDY_FRONTEND" && [[ "${CADDY_FRONTEND}" = "DISABLE_HTTPS" ]]; then
 		https_enabled=false
+		caddy_config_file="${caddyfile_cleartext}"
+	else
+		caddy_config_file="${caddyfile_https}"
 		return
 	fi
 
@@ -427,7 +420,7 @@ check_config_files() {
 
 	create_headscale_config
 
-	create_caddyfile
+	create_config_from_template "${caddy_config_file}" "Caddy configuration file"
 
 	reuse_or_create_noise_private_key
 }
@@ -496,17 +489,10 @@ display_configuration_summary() {
 start_caddy_service() {
 	log_info "Starting Caddy using our environment variables."
 
-	if ${https_enabled}; then
-		caddy start --config "${caddyfile_https}" || {
-			log_error "Failed to start Caddy with HTTPS config"
-			return
-		}
-	else
-		caddy start --config "${caddyfile_cleartext}" || {
-			log_error "Failed to start Caddy with cleartext config"
-			return
-		}
-	fi
+	caddy start --config "${caddy_config_file}" || {
+		log_error "Failed to start Caddy"
+		return
+	}
 
 	# Verify Caddy is actually running
 	sleep 2

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -319,9 +319,9 @@ check_caddy_environment_variables() {
 	if env_var_is_defined "CADDY_FRONTEND" && [[ "${CADDY_FRONTEND}" = "DISABLE_HTTPS" ]]; then
 		https_enabled=false
 		caddy_config_file="${caddyfile_cleartext}"
+		return
 	else
 		caddy_config_file="${caddyfile_https}"
-		return
 	fi
 
 	require_env_var "ACME_ISSUANCE_EMAIL"

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -197,31 +197,6 @@ check_headscale_environment_vars() {
 }
 
 #######################################
-# Create our Headscale configuration file
-#######################################
-create_headscale_config() {
-	# Ensure all template variables are exported for envsubst
-    local template_vars=(
-        "ACME_EAB_BLOCK"
-        "CLOUDFLARE_ACME_BLOCK"
-        "SECURITY_HEADERS_BLOCK"
-        "PUBLIC_SERVER_URL"
-        "PUBLIC_LISTEN_PORT"
-        "HEADSCALE_DNS_BASE_DOMAIN"
-        "HEADSCALE_OVERRIDE_LOCAL_DNS"
-        "MAGIC_DNS"
-        "IP_PREFIXES"
-        "IP_ALLOCATION"
-        "HEADSCALE_EXTRA_RECORDS_PATH"
-    )
-	for var in "${template_vars[@]}"; do
-		export "${var}=${!var}"
-	done
-
-	create_config_from_template "${headscale_config}" "Headscale configuration file"
-}
-
-#######################################
 # Validate ZeroSSL EAB credentials if provided and modify Caddyfile as needed
 #######################################
 check_zerossl_eab() {
@@ -418,7 +393,7 @@ check_config_files() {
 		export "${var}=${!var}"
 	done
 
-	create_headscale_config
+	create_config_from_template "${headscale_config}" "Headscale configuration file"
 
 	create_config_from_template "${caddy_config_file}" "Caddy configuration file"
 


### PR DESCRIPTION
This pull request simplifies the handling of Caddy configuration in the `container-entrypoint.sh` script. The main improvement is the consolidation of logic for selecting and using the appropriate Caddy configuration file, reducing code duplication and making the script easier to maintain. The changes also remove some now-unnecessary helper functions.

**Improvements to configuration handling:**

* Introduced the `caddy_config_file` variable to consistently reference the correct Caddy configuration file (either HTTPS or cleartext) throughout the script, reducing repeated conditional logic. [[1]](diffhunk://#diff-bca9c399655ff26c2cb84c9fd53cccc5ce515604028c1799753b9100ed91e1c0R20) [[2]](diffhunk://#diff-bca9c399655ff26c2cb84c9fd53cccc5ce515604028c1799753b9100ed91e1c0R321-R323)

* Updated the process for creating configuration files to use `create_config_from_template` directly with the new `caddy_config_file` variable, removing the dedicated `create_headscale_config` and `create_caddyfile` helper functions. [[1]](diffhunk://#diff-bca9c399655ff26c2cb84c9fd53cccc5ce515604028c1799753b9100ed91e1c0L198-L233) [[2]](diffhunk://#diff-bca9c399655ff26c2cb84c9fd53cccc5ce515604028c1799753b9100ed91e1c0L428-R398)

**Simplification of Caddy startup logic:**

* Refactored the `start_caddy_service` function to always use `caddy_config_file` when starting Caddy, eliminating the need for repeated conditional checks on `https_enabled`.