### PR TITLE
Broken admin panel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
 
     RUN mv /app/build /app${HEADSCALE_ADMIN_ENDPOINT}
 
+    RUN apk del BuildTimeDeps
+
 # Build our main image
 FROM alpine:${MAIN_IMAGE_ALPINE_VERSION}
     # Set SHELL flags for RUN commands to allow -e and pipefail

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
     RUN git clone --depth 1 --branch ${HEADSCALE_ADMIN_VERSION} ${HEADSCALE_ADMIN_REPO} /app
     WORKDIR /app
 
-    RUN export ENDPOINT="${HEADSCALE_ADMIN_ENDPOINT}"; \
-        npm install; \
+    ENV ENDPOINT="${HEADSCALE_ADMIN_ENDPOINT}"
+    RUN npm install; \
         npm run build;
 
     RUN mv /app/build /app${HEADSCALE_ADMIN_ENDPOINT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,7 @@ FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
     WORKDIR /app
 
     ENV ENDPOINT="${HEADSCALE_ADMIN_ENDPOINT}"
-    RUN npm install; \
-        npm run build;
+    RUN npm install && npm run build;
 
     RUN mv /app/build /app${HEADSCALE_ADMIN_ENDPOINT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG LITESTREAM_SHA256="e8612ef5424802723e8cfa2d07a182df60f9af71839b5ff5ef1e80dff
 # We're building these from source, so we need to specify the versions here rather than hash
 ARG HEADSCALE_ADMIN_ENDPOINT="/admin"
 ARG HEADSCALE_ADMIN_REPO="https://github.com/serein-213/headscale-admin-il18n"
-ARG HEADSCALE_ADMIN_VERSION="main"
+ARG HEADSCALE_ADMIN_VERSION="7da5aa3f89cb1027d086256c176cdb2112d6641c"
 ARG HEADSCALE_ADMIN_NODE_VERSION="22"
 
 # No checksum needed for these tools, we pull from official images
@@ -51,7 +51,9 @@ FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
     RUN apk --no-cache upgrade; \
         apk add --no-cache --virtual BuildTimeDeps git;
 
-    RUN git clone --depth 1 --branch ${HEADSCALE_ADMIN_VERSION} ${HEADSCALE_ADMIN_REPO} /app
+    RUN git clone ${HEADSCALE_ADMIN_REPO} /app && \
+        cd /app && \
+        git checkout ${HEADSCALE_ADMIN_VERSION}
     WORKDIR /app
 
     ENV ENDPOINT="${HEADSCALE_ADMIN_ENDPOINT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 # Tool version arguments
 # Bump these every time there is a new release.
 # We're pulling these from github source, don't forget to bump the checksum!
-ARG HEADSCALE_VERSION="0.27.1"
-ARG HEADSCALE_SHA256="af2a232ff407c100f05980b4d8fceaafc7fdb2e8de5eba8e184a8bb029cb6c00"
+ARG HEADSCALE_VERSION="0.28.0"
+ARG HEADSCALE_SHA256="95f242a31003d60646d233b14a1acacac20d8f319886d0441df085cc3a920f2d"
 
 ARG LITESTREAM_VERSION="0.5.9"
 ARG LITESTREAM_SHA256="e8612ef5424802723e8cfa2d07a182df60f9af71839b5ff5ef1e80dff38efbdd"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,15 @@ ARG HEADSCALE_SHA256="af2a232ff407c100f05980b4d8fceaafc7fdb2e8de5eba8e184a8bb029
 ARG LITESTREAM_VERSION="0.5.9"
 ARG LITESTREAM_SHA256="e8612ef5424802723e8cfa2d07a182df60f9af71839b5ff5ef1e80dff38efbdd"
 
+# We're building these from source, so we need to specify the versions here rather than hash
+ARG HEADSCALE_ADMIN_ENDPOINT="/admin"
+ARG HEADSCALE_ADMIN_REPO="https://github.com/serein-213/headscale-admin-il18n"
+ARG HEADSCALE_ADMIN_VERSION="main"
+ARG HEADSCALE_ADMIN_NODE_VERSION="22"
+
 # No checksum needed for these tools, we pull from official images
 ARG CADDY_VERSION="2.11.1"
 ARG MAIN_IMAGE_ALPINE_VERSION="3.23.3"
-ARG HEADSCALE_ADMIN_VERSION="0.26.0"
 
 # github download links
 # These should never need adjusting unless the URIs change
@@ -33,8 +38,27 @@ FROM caddy:${CADDY_VERSION}-builder AS caddy-builder
     RUN xcaddy build \
         --with github.com/caddy-dns/cloudflare
 
-# Docker hates variables in COPY, apparently. Hello, workaround.
-FROM goodieshq/headscale-admin:${HEADSCALE_ADMIN_VERSION} AS admin-gui
+# Build the admin GUI from source
+FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
+    # Set SHELL flags for RUN commands to allow -e and pipefail
+    # Rationale: https://github.com/hadolint/hadolint/wiki/DL4006
+    SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+    ARG HEADSCALE_ADMIN_REPO
+    ARG HEADSCALE_ADMIN_VERSION
+    ARG HEADSCALE_ADMIN_ENDPOINT
+
+    RUN apk --no-cache upgrade; \
+        apk add --no-cache --virtual BuildTimeDeps git;
+
+    RUN git clone --depth 1 --branch ${HEADSCALE_ADMIN_VERSION} ${HEADSCALE_ADMIN_REPO} /app
+    WORKDIR /app
+
+    RUN ENDPOINT=${HEADSCALE_ADMIN_ENDPOINT}; \
+        npm install; \
+        npm run build;
+
+    RUN mv /app/build /app${HEADSCALE_ADMIN_ENDPOINT}
 
 # Build our main image
 FROM alpine:${MAIN_IMAGE_ALPINE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
     RUN git clone --depth 1 --branch ${HEADSCALE_ADMIN_VERSION} ${HEADSCALE_ADMIN_REPO} /app
     WORKDIR /app
 
-    RUN ENDPOINT=${HEADSCALE_ADMIN_ENDPOINT}; \
+    RUN export ENDPOINT="${HEADSCALE_ADMIN_ENDPOINT}"; \
         npm install; \
         npm run build;
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | --- | --- | --- |
 | [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.3`](https://git.alpinelinux.org/aports/log/?h=v3.23.3) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.27.1`](https://github.com/juanfont/headscale/releases/tag/v0.27.1) |
-| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`0.26.0`](https://github.com/GoodiesHQ/headscale-admin/commit/6cf2bc7d59165757a70f4c918a032225eb5e6e7d) |
+| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`main`](https://github.com/serein-213/headscale-admin-il18n) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.9`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.9) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.1`](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) |
 
@@ -61,8 +61,8 @@ Note that applying this will cause your application to restart, but afterwards n
 [alpine-linux-repo]: https://gitlab.alpinelinux.org/alpine
 [caddy-wob]: https://caddyserver.com/
 [caddy-repo]: https://github.com/caddyserver/caddy
-[headscale-admin-wob]: https://github.com/GoodiesHQ/headscale-admin
-[headscale-admin-repo]: https://github.com/GoodiesHQ/headscale-admin
+[headscale-admin-wob]: https://github.com/serein-213/headscale-admin-il18n
+[headscale-admin-repo]: https://github.com/serein-213/headscale-admin-il18n
 [headscale-wob]: https://headscale.net/
 [headscale-repo]: https://github.com/juanfont/headscale
 [litestream-wob]: https://litestream.io/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | --- | --- | --- |
 | [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.3`](https://git.alpinelinux.org/aports/log/?h=v3.23.3) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
-| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`main`](https://github.com/serein-213/headscale-admin-il18n) |
+| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`7da5aa3`](https://github.com/serein-213/headscale-admin-il18n/commit/7da5aa3f89cb1027d086256c176cdb2112d6641c) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.9`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.9) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.1`](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) |
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.9`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.9) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.1`](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) |
 
+NB: `Headscale-Admin` is deprecated in this release as it appears to have been abandoned by upstream. We have moved to a fork with patches, but intend to replace by `0.29.X`.
+
 ## Versioning
 
 Because of the mix of upstream tools included, this project will be tagged using the versioning style `YYYY.MM.REVISION`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | Tool | Upstream Repository | Version |
 | --- | --- | --- |
 | [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.3`](https://git.alpinelinux.org/aports/log/?h=v3.23.3) |
-| [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.27.1`](https://github.com/juanfont/headscale/releases/tag/v0.27.1) |
+| [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`main`](https://github.com/serein-213/headscale-admin-il18n) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.9`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.9) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.1`](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.9`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.9) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.1`](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) |
 
-NB: `Headscale-Admin` is deprecated in this release as it appears to have been abandoned by upstream. We have moved to a fork with patches, but intend to replace by `0.29.X`.
+DEPRECATION NOTICE: `Headscale-Admin` is deprecated in this release as it appears to have been abandoned by upstream. We have moved to a fork with patches so we can take advantage of the improvements in Headscale's `0.28.X` release, but are actively testing replacement admin panels before Headscale's `0.29.X` releases.
 
 ## Versioning
 

--- a/templates/headscale.template.yaml
+++ b/templates/headscale.template.yaml
@@ -396,3 +396,23 @@ logtail:
 # default static port 41641. This option is intended as a workaround for some buggy
 # firewall devices. See https://tailscale.com/kb/1181/firewalls/ for more information.
 randomize_client_port: false
+
+# Taildrop configuration
+# Taildrop is the file sharing feature of Tailscale, allowing nodes to send files to each other.
+# https://tailscale.com/kb/1106/taildrop/
+taildrop:
+  # Enable or disable Taildrop for all nodes.
+  # When enabled, nodes can send files to other nodes owned by the same user.
+  # Tagged devices and cross-user transfers are not permitted by Tailscale clients.
+  enabled: true
+# Advanced performance tuning parameters.
+# The defaults are carefully chosen and should rarely need adjustment.
+# Only modify these if you have identified a specific performance issue.
+#
+# tuning:
+#   # NodeStore write batching configuration.
+#   # The NodeStore batches write operations before rebuilding peer relationships,
+#   # which is computationally expensive. Batching reduces rebuild frequency.
+#   #
+#   # node_store_batch_size: 100
+#   # node_store_batch_timeout: 500ms


### PR DESCRIPTION
This pull request transitions the Headscale Admin GUI from using a prebuilt Docker image to building from source using a maintained fork (serein-213/headscale-admin-il18n), addresses the deprecation of the original GoodiesHQ/headscale-admin project, and upgrades Headscale from v0.27.1 to v0.28.0. The changes enable continued compatibility with newer Headscale releases whilst the project evaluates long-term admin panel alternatives.

Changes:

- Switched Headscale-Admin from prebuilt image to source-based build using a forked repository
- Updated Headscale from v0.27.1 to v0.28.0 with corresponding SHA256 checksum
- Added deprecation notice warning users about the temporary nature of the current admin panel solution