### PR TITLE
Bump Caddy to `2.11.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG HEADSCALE_ADMIN_VERSION="7da5aa3f89cb1027d086256c176cdb2112d6641c"
 ARG HEADSCALE_ADMIN_NODE_VERSION="22"
 
 # No checksum needed for these tools, we pull from official images
-ARG CADDY_VERSION="2.11.1"
+ARG CADDY_VERSION="2.11.2"
 ARG MAIN_IMAGE_ALPINE_VERSION="3.23.3"
 
 # github download links

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`7da5aa3`](https://github.com/serein-213/headscale-admin-il18n/commit/7da5aa3f89cb1027d086256c176cdb2112d6641c) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.11`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.11) |
-| [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.1`](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) |
+| [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.2`](https://github.com/caddyserver/caddy/releases/tag/v2.11.2) |
 
 DEPRECATION NOTICE: `Headscale-Admin` is deprecated in this release as it appears to have been abandoned by upstream. We have moved to a fork with patches so we can take advantage of the improvements in Headscale's `0.28.X` release, but are actively testing replacement admin panels before Headscale's `0.29.X` releases.
 


### PR DESCRIPTION
This pull request updates the version of Caddy used in the project from 2.11.1 to 2.11.2. The change is reflected both in the `Dockerfile` and in the documentation to ensure consistency between the build and the published version information.

Dependency update:

* Updated the `CADDY_VERSION` argument in the `Dockerfile` from `2.11.1` to `2.11.2` to use the latest Caddy release.

Documentation update:

* Updated the Caddy version in the `README.md` to reflect the new version (`v2.11.2`) and linked to the appropriate release notes.