### PR TITLE
Fix false positives, check the generated config

### DIFF
--- a/.github/workflows/headscale-config-checker.yml
+++ b/.github/workflows/headscale-config-checker.yml
@@ -31,19 +31,7 @@ jobs:
         run: |
           # Source the defaults
           source scripts/defaults.sh
-          
-          # Export default values for envsubst
-          export IP_PREFIXES="${IP_PREFIXES:-"v4: 100.64.0.0/10
-  v6: fd7a:115c:a1e0::/48"}"
-
-          export PUBLIC_SERVER_URL="https://example.com"
-          export PUBLIC_LISTEN_PORT="443"
-          export HEADSCALE_DNS_BASE_DOMAIN="example.com"
-          export HEADSCALE_OVERRIDE_LOCAL_DNS="true"
-          export MAGIC_DNS="true"
-          export IP_ALLOCATION="sequential"
-          export HEADSCALE_EXTRA_RECORDS_PATH="/data/headscale/extra-records.json"
-          export EPHEMERAL_NODE_INACTIVITY_TIMEOUT="30m"
+          source scripts/ci-defaults.sh
           
           # Generate config
           envsubst < templates/headscale.template.yaml > generated-config.yaml

--- a/.github/workflows/headscale-config-checker.yml
+++ b/.github/workflows/headscale-config-checker.yml
@@ -27,6 +27,27 @@ jobs:
           
           echo "Successfully downloaded upstream config"
       
+      - name: Generate config from template with defaults
+        run: |
+          # Source the defaults
+          source scripts/defaults.sh
+          
+          # Export default values for envsubst
+          export IP_PREFIXES="${IP_PREFIXES:-"v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48"}"
+
+          export PUBLIC_SERVER_URL="https://example.com"
+          export PUBLIC_LISTEN_PORT="443"
+          export HEADSCALE_DNS_BASE_DOMAIN="example.com"
+          export HEADSCALE_OVERRIDE_LOCAL_DNS="true"
+          export MAGIC_DNS="true"
+          export IP_ALLOCATION="sequential"
+          export HEADSCALE_EXTRA_RECORDS_PATH="/data/headscale/extra-records.json"
+          export EPHEMERAL_NODE_INACTIVITY_TIMEOUT="30m"
+          
+          # Generate config
+          envsubst < templates/headscale.template.yaml > generated-config.yaml
+      
       - name: Check for new options
         id: check
         run: |
@@ -40,20 +61,20 @@ jobs:
 
           # Get list of keys to ignore from DIFF_IGNORE comments (including commented lines)
           get_ignored_keys() {
-            grep "# DIFF_IGNORE" "$1" | \
+            grep "# DIFF_IGNORE" "templates/headscale.template.yaml" | \
             sed -E 's/^[[:space:]]*#?[[:space:]]*//' | \
             sed -E 's/:.*# DIFF_IGNORE.*$//' | \
             sort -u
           }
 
           echo "=== Getting ignored keys ==="
-          get_ignored_keys "templates/headscale.template.yaml" > ignored_keys.txt
+          get_ignored_keys > ignored_keys.txt
           echo "Keys to ignore:"
           cat ignored_keys.txt
           echo "=== End ignored keys ==="
 
           # Extract all keys
-          extract_keys "templates/headscale.template.yaml" > local_all_keys.txt
+          extract_keys "generated-config.yaml" > local_all_keys.txt
           extract_keys "upstream-config.yaml" > upstream_all_keys.txt
 
           # Normalize keys (strip optional leading '#' and surrounding spaces) and sort-unique

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# CI-specific defaults for config generation
+# These are used in the GitHub Actions workflow to generate a baseline config
+
+# Export default values for envsubst in templates
+# shellcheck disable=SC2034
+export IP_PREFIXES="v4: $headscale_ipv4_prefix_default
+v6: $headscale_ipv6_prefix_default"
+
+export PUBLIC_SERVER_URL="https://example.com"
+export PUBLIC_LISTEN_PORT="443"
+export HEADSCALE_DNS_BASE_DOMAIN="example.com"
+export HEADSCALE_OVERRIDE_LOCAL_DNS="true"
+export MAGIC_DNS="true"
+export IP_ALLOCATION="sequential"
+export HEADSCALE_EXTRA_RECORDS_PATH="/data/headscale/extra-records.json"
+export EPHEMERAL_NODE_INACTIVITY_TIMEOUT="30m"

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -7,7 +7,7 @@
 export IP_PREFIXES="v4: $headscale_ipv4_prefix_default
 v6: $headscale_ipv6_prefix_default"
 
-export PUBLIC_SERVER_URL="https://example.com"
+export PUBLIC_SERVER_URL="example.com"
 export PUBLIC_LISTEN_PORT="443"
 export HEADSCALE_DNS_BASE_DOMAIN="example.com"
 export HEADSCALE_OVERRIDE_LOCAL_DNS="true"

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -5,7 +5,7 @@
 # Export default values for envsubst in templates
 # shellcheck disable=SC2034
 export IP_PREFIXES="v4: $headscale_ipv4_prefix_default
-v6: $headscale_ipv6_prefix_default"
+  v6: $headscale_ipv6_prefix_default"
 
 export PUBLIC_SERVER_URL="example.com"
 export PUBLIC_LISTEN_PORT="443"

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -3,7 +3,7 @@
 # These are used in the GitHub Actions workflow to generate a baseline config
 
 # Export default values for envsubst in templates
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 export IP_PREFIXES="v4: $headscale_ipv4_prefix_default
   v6: $headscale_ipv6_prefix_default"
 export PUBLIC_SERVER_URL="example.com"

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -6,12 +6,11 @@
 # shellcheck disable=SC2034
 export IP_PREFIXES="v4: $headscale_ipv4_prefix_default
   v6: $headscale_ipv6_prefix_default"
-
 export PUBLIC_SERVER_URL="example.com"
-export PUBLIC_LISTEN_PORT="443"
+export PUBLIC_LISTEN_PORT="$public_listen_port_default"
 export HEADSCALE_DNS_BASE_DOMAIN="example.com"
-export HEADSCALE_OVERRIDE_LOCAL_DNS="true"
-export MAGIC_DNS="true"
-export IP_ALLOCATION="sequential"
-export HEADSCALE_EXTRA_RECORDS_PATH="/data/headscale/extra-records.json"
-export EPHEMERAL_NODE_INACTIVITY_TIMEOUT="30m"
+export HEADSCALE_OVERRIDE_LOCAL_DNS="$headscale_override_local_dns_default"
+export MAGIC_DNS="$headscale_magic_dns_default"
+export IP_ALLOCATION="$headscale_ip_allocation_default"
+export HEADSCALE_EXTRA_RECORDS_PATH="$headscale_extra_records_path_default"
+export EPHEMERAL_NODE_INACTIVITY_TIMEOUT="$headscale_ephemeral_node_inactivity_timeout_default"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the Headscale config checker to improve how configuration files are generated and compared. The main changes involve generating a config from a template using default values and updating the key extraction logic to use the generated config, ensuring that the comparison is based on actual default values.

**Config generation improvements:**

* Added a step to generate `generated-config.yaml` from `templates/headscale.template.yaml` using environment variables set with default values from `scripts/defaults.sh`, ensuring the config is always generated with consistent defaults.

**Key extraction and comparison updates:**

* Updated the ignored keys extraction to always use `templates/headscale.template.yaml` and simplified the function call.
* Changed the key extraction for local keys to use the generated config (`generated-config.yaml`) instead of the template, making the comparison more accurate.