### PR TITLE
Bump `headscale-admin` to support `v0.28.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG LITESTREAM_SHA256="2f80fdb6b0a0ff7a116ee37adf02d3de8e977ef76e052b28a6690218f
 # We're building these from source, so we need to specify the versions here rather than hash
 ARG HEADSCALE_ADMIN_ENDPOINT="/admin"
 ARG HEADSCALE_ADMIN_REPO="https://github.com/privacyint/headscale-admin"
-ARG HEADSCALE_ADMIN_VERSION="139abd3e2468db4878f0a92895515090697fba3d"
+ARG HEADSCALE_ADMIN_VERSION="v0.28.0"
 ARG HEADSCALE_ADMIN_NODE_VERSION="25"
 
 # No checksum needed for these tools, we pull from official images

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | --- | --- | --- |
 | [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.3`](https://git.alpinelinux.org/aports/log/?h=v3.23.3) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
-| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`139abd2`](https://github.com/privacyint/headscale-admin/commit/139abd3e2468db4878f0a92895515090697fba3d) |
+| [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`v0.28.0`](https://github.com/privacyint/headscale-admin/releases/tag/v0.28.0) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.11`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.11) |
 | [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.2`](https://github.com/caddyserver/caddy/releases/tag/v2.11.2) |
 


### PR DESCRIPTION
This pull request updates the version of the Headscale-Admin dependency to use a tagged release instead of a specific commit hash. This improves clarity and maintainability by referencing a stable, versioned release.

Dependency version updates:

* Updated the `HEADSCALE_ADMIN_VERSION` build argument in the `Dockerfile` from a commit hash to the tagged release `v0.28.0` for Headscale-Admin.
* Updated the Headscale-Admin version reference in the `README.md` to use the `v0.28.0` release tag and corresponding URL, instead of a commit hash.