### PR TITLE
Fix white screens on Admin GUI page reloads/direct access

### DIFF
--- a/.github/workflows/build-with-smoke-tests.yml
+++ b/.github/workflows/build-with-smoke-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run container in detached mode
         run: |
           docker run -d --name headscale-container \
-            -p 8008:8008 \
+            -p 127.0.0.1:8008:8008 \
             --env LITESTREAM_REPLICA_URL=${{ env.LITESTREAM_REPLICA_URL }} \
             --env PUBLIC_SERVER_URL=${{ env.PUBLIC_SERVER_URL }} \
             --env HEADSCALE_DNS_BASE_DOMAIN=${{ env.HEADSCALE_DNS_BASE_DOMAIN }} \

--- a/.github/workflows/build-with-smoke-tests.yml
+++ b/.github/workflows/build-with-smoke-tests.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Run container in detached mode
         run: |
           docker run -d --name headscale-container \
+            -p 8008:8008 \
             --env LITESTREAM_REPLICA_URL=${{ env.LITESTREAM_REPLICA_URL }} \
             --env PUBLIC_SERVER_URL=${{ env.PUBLIC_SERVER_URL }} \
             --env HEADSCALE_DNS_BASE_DOMAIN=${{ env.HEADSCALE_DNS_BASE_DOMAIN }} \
@@ -61,7 +62,36 @@ jobs:
         run: |
           docker exec headscale-container sh -c "netstat -tuln | grep ':8008 '"
 
+      - name: Wait for admin GUI to respond
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl --silent --show-error --fail http://127.0.0.1:8008/admin/ > /tmp/admin-gui.html; then
+              exit 0
+            fi
+
+            sleep 2
+          done
+
+          echo "Admin GUI did not become ready in time"
+          docker logs headscale-container
+          exit 1
+
+      - name: Check admin GUI redirect and content
+        run: |
+          redirect_headers=$(mktemp)
+
+          curl --silent --show-error --fail \
+            --dump-header "$redirect_headers" \
+            --output /dev/null \
+            http://127.0.0.1:8008/admin
+
+          tr -d '\r' < "$redirect_headers" | grep -qi '^location: /admin/$'
+          grep -qi '<!doctype html>' /tmp/admin-gui.html
+          grep -qi 'data-sveltekit-preload-data="hover"' /tmp/admin-gui.html
+          grep -qi 'assets: "/admin"' /tmp/admin-gui.html
+
       - name: Stop and remove container
+        if: always()
         run: |
           docker stop headscale-container
           docker rm headscale-container

--- a/templates/Caddyfile-http.template
+++ b/templates/Caddyfile-http.template
@@ -9,10 +9,10 @@
 :8008 {
 	redir /admin /admin/
 
-	handle_path /admin/* {
-		root * /admin-gui/admin
+	handle /admin/* {
+		root * /admin-gui
 		encode gzip zstd
-		try_files {path}.html {path} index.html
+		try_files {path}.html {path} {path}/index.html /admin/200.html
 		file_server${SECURITY_HEADERS_BLOCK}
 	}
 

--- a/templates/Caddyfile-http.template
+++ b/templates/Caddyfile-http.template
@@ -12,7 +12,20 @@
 	handle /admin/* {
 		root * /admin-gui
 		encode gzip zstd
-		try_files {path}.html {path} {path}/index.html /admin/200.html
+
+		@admin_assets path_regexp admin_assets ^/admin/.*\.[^/]+$
+		handle @admin_assets {
+			file_server${SECURITY_HEADERS_BLOCK}
+		}
+
+		@admin_navigation {
+			header Accept *text/html*
+			not path_regexp admin_navigation_assets ^/admin/.*\.[^/]+$
+		}
+		handle @admin_navigation {
+			try_files {path}.html {path} {path}/index.html /admin/200.html
+			file_server${SECURITY_HEADERS_BLOCK}
+		}
 		file_server${SECURITY_HEADERS_BLOCK}
 	}
 

--- a/templates/Caddyfile-https.template
+++ b/templates/Caddyfile-https.template
@@ -14,7 +14,25 @@ ${PUBLIC_SERVER_URL}:${PUBLIC_LISTEN_PORT} {
 	handle /admin/* {
 		root * /admin-gui
 		encode gzip zstd
-		try_files {path}.html {path} {path}/index.html /admin/200.html
+
+		@admin_asset path_regexp admin_asset ^/admin/.*\.[^/]+$
+		handle @admin_asset {
+			file_server${SECURITY_HEADERS_BLOCK}
+		}
+
+		@admin_existing file {
+			try_files {path}.html {path} {path}/index.html
+		}
+		handle @admin_existing {
+			rewrite * {file_match.relative}
+			file_server${SECURITY_HEADERS_BLOCK}
+		}
+
+		@admin_html header Accept *text/html*
+		handle @admin_html {
+			rewrite * /admin/200.html
+			file_server${SECURITY_HEADERS_BLOCK}
+		}
 		file_server${SECURITY_HEADERS_BLOCK}
 	}
 

--- a/templates/Caddyfile-https.template
+++ b/templates/Caddyfile-https.template
@@ -11,10 +11,10 @@
 ${PUBLIC_SERVER_URL}:${PUBLIC_LISTEN_PORT} {
 	redir /admin /admin/
 
-	handle_path /admin/* {
-		root * /admin-gui/admin
+	handle /admin/* {
+		root * /admin-gui
 		encode gzip zstd
-		try_files {path}.html {path} index.html
+		try_files {path}.html {path} {path}/index.html /admin/200.html
 		file_server${SECURITY_HEADERS_BLOCK}
 	}
 


### PR DESCRIPTION
This pull request updates the admin GUI serving logic and improves the smoke test workflow for the admin interface. The changes ensure that the admin GUI is served from the correct directory, handle trailing slashes and error pages more gracefully, and add automated checks to verify the GUI is up and responding as expected during CI.

**Admin GUI serving improvements:**

* Updated both `Caddyfile-http.template` and `Caddyfile-https.template` to serve the admin GUI from the `/admin-gui` directory instead of `/admin-gui/admin`, and switched from `handle_path` to `handle` for `/admin/*` routes. The `try_files` directive now includes `{path}/index.html` and a fallback to `/admin/200.html` for better error handling. [[1]](diffhunk://#diff-53d1f688dac2479ca215eeb2639aebdb088189534e6f3fb9cf80052a283d7a83L12-R15) [[2]](diffhunk://#diff-eac4c8dfa1841a895952940f1ec3250152c40a39c14ba22e0292cd4e5785aaa5L14-R17)

**CI workflow enhancements:**

* Modified the smoke test workflow (`.github/workflows/build-with-smoke-tests.yml`) to expose port 8008 in the test container, wait for the admin GUI to become responsive, and add checks for expected redirects and HTML content. This ensures the admin GUI is correctly deployed and functional in CI. [[1]](diffhunk://#diff-7daa172b4216a5a0eb88eaf19dfe8ea8b1ef1a2f0b9def7f044ea3df51224bd8R48) [[2]](diffhunk://#diff-7daa172b4216a5a0eb88eaf19dfe8ea8b1ef1a2f0b9def7f044ea3df51224bd8R65-R94)