### PR TITLE
Bump Alpine to `v3.23.4`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG HEADSCALE_ADMIN_NODE_VERSION="25"
 
 # No checksum needed for these tools, we pull from official images
 ARG CADDY_VERSION="2.11.2"
-ARG MAIN_IMAGE_ALPINE_VERSION="3.23.3"
+ARG MAIN_IMAGE_ALPINE_VERSION="3.23.4"
 
 # github download links
 # These should never need adjusting unless the URIs change

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 
 | Tool | Upstream Repository | Version |
 | --- | --- | --- |
-| [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.3`](https://git.alpinelinux.org/aports/log/?h=v3.23.3) |
+| [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.23.4`](https://git.alpinelinux.org/aports/log/?h=v3.23.4) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`v0.28.0`](https://github.com/privacyint/headscale-admin/releases/tag/v0.28.0) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.11`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.11) |


### PR DESCRIPTION
This pull request updates the base Alpine Linux version used in the Docker image and documentation from `3.23.3` to `3.23.4`. This ensures the image uses the latest patch release, which may include important security and bug fixes.

Version update:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-R21): Updated the `MAIN_IMAGE_ALPINE_VERSION` argument from `3.23.3` to `3.23.4` to use the latest Alpine Linux patch release.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9): Updated the documented Alpine Linux version to reflect the new version `v3.23.4`.