### PR TITLE
Bump runner dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/build-with-smoke-tests.yml
+++ b/.github/workflows/build-with-smoke-tests.yml
@@ -22,16 +22,16 @@ jobs:
       CADDY_FRONTEND: "DISABLE_HTTPS"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
       - name: Create cache directory
         run: mkdir -p /tmp/.buildx-cache
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/bump-upstream-releases.yml
+++ b/.github/workflows/bump-upstream-releases.yml
@@ -69,7 +69,7 @@ jobs:
             upstream_tag_prefix: v
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Bump dependency files
         id: bump
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create pull request
         if: steps.bump.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           # A fine-grained PAT (stored as BUMP_PR_TOKEN) is required here instead of
           # github.token so that the created PR triggers CI workflow runs.
@@ -134,7 +134,7 @@ jobs:
             release_url_template: https://git.alpinelinux.org/aports/log/?h=v{version}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Bump dependency files
         id: bump
@@ -153,7 +153,7 @@ jobs:
 
       - name: Create pull request
         if: steps.bump.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           # A fine-grained PAT (stored as BUMP_PR_TOKEN) is required here instead of
           # github.token so that the created PR triggers CI workflow runs.

--- a/.github/workflows/enforce-sha-pinned-actions.yml
+++ b/.github/workflows/enforce-sha-pinned-actions.yml
@@ -24,8 +24,8 @@ jobs:
           non_pinned_actions=$(
             grep -RInE '^[[:space:]]*uses:[[:space:]]*' .github/workflows | \
               grep -vE 'uses:[[:space:]]*\./' | \
-              grep -vE 'uses:[[:space:]]*[^[:space:]]+@[a-f0-9]{40}([[:space:]]*#.*)?$' | \
-              grep -vE 'uses:[[:space:]]*docker://[^@[:space:]]+@sha256:[a-f0-9]{64}([[:space:]]*#.*)?$' || true
+              grep -vE 'uses:[[:space:]]*[^[:space:]]+@[A-Fa-f0-9]{40}([[:space:]]*#.*)?$' | \
+              grep -vE 'uses:[[:space:]]*docker://[^@[:space:]]+@sha256:[A-Fa-f0-9]{64}([[:space:]]*#.*)?$' || true
           )
 
           if [[ -n "$non_pinned_actions" ]]; then

--- a/.github/workflows/enforce-sha-pinned-actions.yml
+++ b/.github/workflows/enforce-sha-pinned-actions.yml
@@ -1,0 +1,35 @@
+name: Enforce SHA-Pinned Actions
+
+on:
+  pull_request:
+  push:
+    branches: [ "main", "develop" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-workflow-action-pins:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Check workflow action pins
+        run: |
+          set -euo pipefail
+
+          non_pinned_actions=$(
+            grep -RInE '^[[:space:]]*uses:[[:space:]]*' .github/workflows | \
+              grep -vE 'uses:[[:space:]]*\./' | \
+              grep -vE 'uses:[[:space:]]*[^[:space:]]+@[a-f0-9]{40}([[:space:]]*#.*)?$' | \
+              grep -vE 'uses:[[:space:]]*docker://[^@[:space:]]+@sha256:[a-f0-9]{64}([[:space:]]*#.*)?$' || true
+          )
+
+          if [[ -n "$non_pinned_actions" ]]; then
+            echo 'Found external actions that are not pinned to a full commit SHA or image digest:'
+            echo "$non_pinned_actions"
+            exit 1
+          fi

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -30,10 +30,10 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
+        uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183 # v2.1.0
         with:
           dockerfile: ./Dockerfile
           format: sarif
@@ -41,7 +41,7 @@ jobs:
           no-fail: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3.35.3
         with:
           sarif_file: hadolint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/headscale-config-checker.yml
+++ b/.github/workflows/headscale-config-checker.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       
       - name: Get version and download upstream config
         run: |
@@ -102,7 +102,7 @@ jobs:
       
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.check.outputs.has_missing == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
This pull request introduces improvements to GitHub Actions workflows, focusing on enhanced security and maintainability. The main changes include enforcing SHA-pinned actions, updating workflows to use specific commit SHAs for all third-party actions, and adding Dependabot support for GitHub Actions dependencies.

**Security and Workflow Hardening:**

* Added a new workflow `.github/workflows/enforce-sha-pinned-actions.yml` to automatically check that all external GitHub Actions are pinned to a specific commit SHA, preventing accidental upgrades and improving supply chain security.
* Updated all workflow files (e.g., `build-with-smoke-tests.yml`, `bump-upstream-releases.yml`, `hadolint.yml`, `headscale-config-checker.yml`) to use SHA-pinned versions for all third-party actions, replacing version tags with full commit SHAs and adding version comments for clarity. [[1]](diffhunk://#diff-7daa172b4216a5a0eb88eaf19dfe8ea8b1ef1a2f0b9def7f044ea3df51224bd8L25-R34) [[2]](diffhunk://#diff-69a4b87f83bb7f52076410737c3333764eb20c11b3f8b993f94b9ea703ba5b07L72-R72) [[3]](diffhunk://#diff-69a4b87f83bb7f52076410737c3333764eb20c11b3f8b993f94b9ea703ba5b07L91-R91) [[4]](diffhunk://#diff-69a4b87f83bb7f52076410737c3333764eb20c11b3f8b993f94b9ea703ba5b07L137-R137) [[5]](diffhunk://#diff-69a4b87f83bb7f52076410737c3333764eb20c11b3f8b993f94b9ea703ba5b07L156-R156) [[6]](diffhunk://#diff-93a1f172ec6e4110cd725d72be37e9f155cffa1b2470bcdaa99bb49cfa2201d1L33-R44) [[7]](diffhunk://#diff-24cafe7f4f5eb3a1f4f23bbb75df6e8439f311a7114f20cf10667b8a31d495a6L18-R18) [[8]](diffhunk://#diff-24cafe7f4f5eb3a1f4f23bbb75df6e8439f311a7114f20cf10667b8a31d495a6L105-R105)

**Dependency Management:**

* Enabled Dependabot updates for GitHub Actions by adding a new entry in `.github/dependabot.yml`, ensuring dependencies for workflows are kept up to date.

These changes collectively improve the security, reliability, and maintainability of the project's CI/CD pipelines.