### PR TITLE
deps(caddy): bump to v2.11.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG HEADSCALE_ADMIN_VERSION="v0.28.0"
 ARG HEADSCALE_ADMIN_NODE_VERSION="25"
 
 # No checksum needed for these tools, we pull from official images
-ARG CADDY_VERSION="2.11.3"
+ARG CADDY_VERSION="2.11.4"
 ARG MAIN_IMAGE_ALPINE_VERSION="3.23.4"
 
 # github download links

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`v0.28.0`](https://github.com/privacyint/headscale-admin/releases/tag/v0.28.0) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.11`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.11) |
-| [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.3`](https://github.com/caddyserver/caddy/releases/tag/v2.11.3) |
+| [`Caddy`][caddy-wob] | [Caddy Repo][caddy-repo] | [`v2.11.4`](https://github.com/caddyserver/caddy/releases/tag/v2.11.4) |
 
 NB: `Headscale-Admin` appears to have been abandoned by upstream. We have created a fork with patches so we can take advantage of the improvements in Headscale's `0.28.X` release.
 


### PR DESCRIPTION
## Summary

This automated PR updates the pinned `Caddy` release.

- Current version: `v2.11.3`
- New version: `v2.11.4`
- Upstream release: https://github.com/caddyserver/caddy/releases/tag/v2.11.4
- Updated checksum asset: `not applicable`

The existing CI workflows will validate the resulting image and config compatibility.