### PR TITLE
Clone into the working dir rather than CDing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,9 @@ FROM node:${HEADSCALE_ADMIN_NODE_VERSION}-alpine AS admin-gui
     RUN apk --no-cache upgrade; \
         apk add --no-cache --virtual BuildTimeDeps git;
 
-    RUN git clone ${HEADSCALE_ADMIN_REPO} /app && \
-        cd /app && \
-        git checkout ${HEADSCALE_ADMIN_VERSION}
     WORKDIR /app
+    RUN git clone ${HEADSCALE_ADMIN_REPO} . && \
+        git checkout ${HEADSCALE_ADMIN_VERSION}
 
     ENV ENDPOINT="${HEADSCALE_ADMIN_ENDPOINT}"
     RUN npm install && npm run build;


### PR DESCRIPTION
This pull request makes a small adjustment to the Dockerfile for the admin GUI build stage. The change improves the way the repository is cloned, making the process more efficient and consistent with Docker best practices.

- Changed the `git clone` command to clone the repository directly into the current working directory (`.`) instead of `/app`, and removed the extra `cd /app` step.