### PR TITLE
Improve reverse proxy work, add captive portal detection

### DIFF
--- a/templates/Caddyfile-http.template
+++ b/templates/Caddyfile-http.template
@@ -7,6 +7,11 @@
 }
 
 :8008 {
+	# Tailscale captive portal detection
+	handle /generate_204 {
+		respond 204
+	}
+
 	redir /admin /admin/
 
 	handle /admin/* {

--- a/templates/Caddyfile-https.template
+++ b/templates/Caddyfile-https.template
@@ -10,6 +10,11 @@
 }
 
 ${PUBLIC_SERVER_URL}:${PUBLIC_LISTEN_PORT} {
+	# Tailscale captive portal detection
+	handle /generate_204 {
+		respond 204
+	}
+
 	redir /admin /admin/
 
 	handle /admin/* {

--- a/templates/headscale.template.yaml
+++ b/templates/headscale.template.yaml
@@ -40,9 +40,9 @@ grpc_allow_insecure: false
 
 # CIDR(s) of reverse proxies (e.g. 127.0.0.1/32) whose
 # True-Client-IP, X-Real-IP and X-Forwarded-For headers should
-# be honoured. Empty (default) ignores those headers; setting
-# this without a proxy in front lets clients spoof their logged
-# source IP.
+# be honoured. This template trusts loopback by default (for the bundled Caddy);
+# set to [] to disable, or replace with your proxy CIDRs. Setting this
+# without a proxy in front lets clients spoof their logged source IP.
 trusted_proxies:
   - 127.0.0.1/32
   - ::1/128

--- a/templates/headscale.template.yaml
+++ b/templates/headscale.template.yaml
@@ -38,6 +38,15 @@ grpc_listen_addr: 127.0.0.1:50443
 # are doing.
 grpc_allow_insecure: false
 
+# CIDR(s) of reverse proxies (e.g. 127.0.0.1/32) whose
+# True-Client-IP, X-Real-IP and X-Forwarded-For headers should
+# be honoured. Empty (default) ignores those headers; setting
+# this without a proxy in front lets clients spoof their logged
+# source IP.
+trusted_proxies:
+  - 127.0.0.1/32
+  - ::1/128
+
 # The Noise section includes specific configuration for the
 # TS2021 Noise protocol
 noise:


### PR DESCRIPTION
This pull request adds support for Tailscale captive portal detection and improves reverse proxy handling in the configuration templates. The main changes are the addition of a handler for the `/generate_204` endpoint in both HTTP and HTTPS Caddyfile templates, and the introduction of a `trusted_proxies` setting in the Headscale YAML template to properly honor client IP headers from trusted proxies.

**Captive portal detection:**
* Added a handler for `/generate_204` in both `Caddyfile-http.template` and `Caddyfile-https.template` to respond with HTTP 204, supporting Tailscale's captive portal detection mechanism. [[1]](diffhunk://#diff-53d1f688dac2479ca215eeb2639aebdb088189534e6f3fb9cf80052a283d7a83R10-R14) [[2]](diffhunk://#diff-eac4c8dfa1841a895952940f1ec3250152c40a39c14ba22e0292cd4e5785aaa5R13-R17)

**Reverse proxy configuration:**
* Introduced a `trusted_proxies` section in `headscale.template.yaml` to specify which proxy IP ranges are trusted for `True-Client-IP`, `X-Real-IP`, and `X-Forwarded-For` headers, improving security and correct client IP logging.