### PR TITLE
deps(alpine-linux): bump to v3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG HEADSCALE_ADMIN_NODE_VERSION="25"
 
 # No checksum needed for these tools, we pull from official images
 ARG CADDY_VERSION="2.11.4"
-ARG MAIN_IMAGE_ALPINE_VERSION="3.24.0"
+ARG MAIN_IMAGE_ALPINE_VERSION="3.24.1"
 
 # github download links
 # These should never need adjusting unless the URIs change

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploy [Headscale][headscale-wob] using a "serverless" immutable docker image wi
 
 | Tool | Upstream Repository | Version |
 | --- | --- | --- |
-| [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.24.0`](https://git.alpinelinux.org/aports/log/?h=v3.24.0) |
+| [`Alpine Linux`][alpine-linux-wob] | [Alpine Linux Repo][alpine-linux-repo] | [`v3.24.1`](https://git.alpinelinux.org/aports/log/?h=v3.24.1) |
 | [`Headscale`][headscale-wob] | [Headscale Repo][headscale-repo] | [`v0.28.0`](https://github.com/juanfont/headscale/releases/tag/v0.28.0) |
 | [`Headscale-Admin`][headscale-admin-wob] | [Headscale-Admin Repo][headscale-admin-repo] | [`v0.28.0`](https://github.com/privacyint/headscale-admin/releases/tag/v0.28.0) |
 | [`Litestream`][litestream-wob] | [Litestream Repo][litestream-repo] | [`0.5.12`](https://github.com/benbjohnson/litestream/releases/tag/v0.5.12) |


### PR DESCRIPTION
## Summary

This automated PR updates the pinned `Alpine Linux` release.

- Current version: `v3.24.0`
- New version: `v3.24.1`
- Upstream release: https://git.alpinelinux.org/aports/log/?h=v3.24.1

The existing CI workflows will validate the resulting image and config compatibility.